### PR TITLE
The deposition form failed to render …

### DIFF
--- a/ui/mbdb-mst-ui/mbdb_mst_ui/resources/resource.py
+++ b/ui/mbdb-mst-ui/mbdb_mst_ui/resources/resource.py
@@ -6,3 +6,7 @@ class MbdbMstUIResource(RecordsUIResource):
             return super()._get_record(resource_requestctx, allow_draft=False)
         except:
             return super()._get_record(resource_requestctx, allow_draft=True)
+
+    def empty_record(self, resource_requestctx, **kwargs):
+        """Create an empty record with default values. """
+        return {}


### PR DESCRIPTION
…as MbdbMstUIResource.empty_record() relied the method defined in the parent class  which created default values outside the allowed range, e.g. empty string for schema version, now empy_record is defined locally and an empty dict is returned instead. Note this is a local fix for MST only