### PR TITLE
switched to egde_ngram to only match beginings of words rather than m…

### DIFF
--- a/models/settings.yaml
+++ b/models/settings.yaml
@@ -13,9 +13,9 @@ record:
               tokenizer: substringtokenizer
           "tokenizer":
             "substringtokenizer":
-              "type": "ngram"
-              "min_gram": 3
-              "max_gram": 3
+              "type": "egde_ngram"
+              "min_gram": 4
+              "max_gram": 8
               "token_chars":
                 - "letter"
                 - "digit"


### PR DESCRIPTION
too many matches resulting from  the middle of the words, so we'll try with matching only the beginning of words. Fixes #312 