### PR TITLE
sorting measurement 

### DIFF
--- a/ui/bli/templates/semantic-ui/bli/BLI/MeasurementProtocol.jinja
+++ b/ui/bli/templates/semantic-ui/bli/BLI/MeasurementProtocol.jinja
@@ -1,6 +1,6 @@
 {# def measurement_protocol #}
 
-{% for step in array(measurement_protocol) | sort(attribute="start_time.value") %}
+{% for step in array(measurement_protocol) %}
     <div>
         {{ step.name }}
         {{ step.type }}

--- a/ui/spr/templates/semantic-ui/spr/SPR/MeasurementProtocol.jinja
+++ b/ui/spr/templates/semantic-ui/spr/SPR/MeasurementProtocol.jinja
@@ -1,6 +1,6 @@
 {# def measurement_protocol #}
 
-{% for step in array(measurement_protocol) | sort(attribute="start_time.value") %}
+{% for step in array(measurement_protocol) %}
     <div>
         {{ step.name }}
         {{ step.type }}


### PR DESCRIPTION
according to start_time.value doesn't sort correctly, so now it will sort according to array ordering