### PR TITLE
Fix/stage setup script

### DIFF
--- a/common/bootstrap_localdev.sh
+++ b/common/bootstrap_localdev.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Script to populate roles in localdev.
+
+set -e
+set -x
+
+ROLES=(reviewer editor administrator)
+
+for role in "${ROLES[@]}"; do
+    if invenio roles create "$role" 2>/dev/null; then
+        echo "Created role '$role'"
+    else
+        echo "Role '$role' already exists. Skipping."
+    fi
+done
+
+# Run stage setup script afterwards
+bash "$(dirname "$0")/../scripts/stage_setup.sh"

--- a/scripts/stage_setup.sh
+++ b/scripts/stage_setup.sh
@@ -21,7 +21,7 @@ for role in "${ROLES[@]}"; do
     if [[ "$role" == "administrator" ]]; then
         FULL_NAME="Administrátor"
     else
-        FULL_NAME="$(tr '[:lower:]' '[:upper:]' <<< ${role:0:1})${role:1}"
+        FULL_NAME="${role^}"
     fi
 
     PROFILE_JSON="{\"full_name\": \"$FULL_NAME\"}"

--- a/scripts/stage_setup.sh
+++ b/scripts/stage_setup.sh
@@ -38,12 +38,16 @@ for role in "${ROLES[@]}"; do
 
 done
 
-wait
-
+# ------------------------------------------------------
+# Assign each user their role
+# ------------------------------------------------------
 for role in "${ROLES[@]}"; do
     EMAIL="${role}@mbdb.org"
-    invenio roles add "$EMAIL" "$role" &
-    invenio access allow administration-access role "$role" &
+    invenio roles add "$EMAIL" "$role" || echo "Role '$role' already assigned to '$EMAIL'. Skipping."
 done
 
-wait
+# ------------------------------------------------------
+# Allow administration access to the admin role
+# ------------------------------------------------------
+invenio access allow administration-access role administrator || \
+    echo "administrator already has administration-access assigned."

--- a/scripts/stage_setup.sh
+++ b/scripts/stage_setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Script to create users, assign system roles, and grant administration access to admin.
+# Script to create users, assign system roles, and grant administration access to administrator.
+# Requires the environment variable $USERS_PASSWORD to be set before running.
 
 set -e
 set -x

--- a/scripts/stage_setup.sh
+++ b/scripts/stage_setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-#
-# Script to create users, assign system roles, and grant admin access.
-#
+# Script to create users, assign system roles, and grant administration access to admin.
 
 set -e
 set -x
@@ -13,7 +11,7 @@ fi
 
 ROLES=(reviewer editor administrator)
 
-
+# Create users (skip if they already exist)
 for role in "${ROLES[@]}"; do
 
     EMAIL="${role}@mbdb.org"
@@ -38,16 +36,12 @@ for role in "${ROLES[@]}"; do
 
 done
 
-# ------------------------------------------------------
 # Assign each user their role
-# ------------------------------------------------------
 for role in "${ROLES[@]}"; do
     EMAIL="${role}@mbdb.org"
     invenio roles add "$EMAIL" "$role" || echo "Role '$role' already assigned to '$EMAIL'. Skipping."
 done
 
-# ------------------------------------------------------
 # Allow administration access to the admin role
-# ------------------------------------------------------
 invenio access allow administration-access role administrator || \
     echo "administrator already has administration-access assigned."

--- a/scripts/stage_setup.sh
+++ b/scripts/stage_setup.sh
@@ -6,7 +6,10 @@
 set -e
 set -x
 
-DUMMY_PASSWORD='mosbrimbdb2025'
+if [ -z "$USERS_PASSWORD" ] ; then
+  echo "USERS_PASSWORD is not set"
+  exit 1
+fi
 
 ROLES=(reviewer editor administrator)
 

--- a/scripts/stage_setup.sh
+++ b/scripts/stage_setup.sh
@@ -26,7 +26,15 @@ for role in "${ROLES[@]}"; do
 
     PROFILE_JSON="{\"full_name\": \"$FULL_NAME\"}"
 
-    invenio users create -a -c "$EMAIL" --password "$DUMMY_PASSWORD" --profile "$PROFILE_JSON" &
+    if ! invenio users create -a -c "$EMAIL" --password "$USERS_PASSWORD" --profile "$PROFILE_JSON" 2>err.out; then
+        if grep -q "already associated with an account" err.out; then
+            echo "User '$EMAIL' already exists. Skipping."
+        else
+            echo "Error creating user '$EMAIL':"
+            cat err.out
+            exit 1
+        fi
+    fi
 
 done
 


### PR DESCRIPTION
Improves the setup scripts for local development and stage environment.

**Key changes include:**
- Added validation requiring $USERS_PASSWORD to be set before running stage_setup.sh.
- Simplified full-name generation using Bash’s ${role^}.
- Replaced hardcoded dummy password with $USERS_PASSWORD variable.
- Implemented safe user creation: skip if account already exists, fail on unexpected errors.
- Cleaned up role assignment with safe fallbacks when roles are already linked.
- Ensured only the administrator role receives administration-access.
- Added descriptive comments for clarity and maintainability.
- Added a new script bootstrap_localdev.sh to populate base roles in localdev and then run the staging setup (localdev only).