### PR TITLE
Fix/stage script

### DIFF
--- a/common/bootstrap_localdev.sh
+++ b/common/bootstrap_localdev.sh
@@ -1,18 +1,46 @@
 #!/bin/bash
 # Script to populate roles in localdev.
-
 set -e
-set -x
+# --- ANSI Color Codes ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+# ------------------------
 
+unset USERS_PASSWORD
+
+echo -e "${CYAN}--- User Password Setup ---${NC}"
+echo -e "Please enter the password to be used for the default users (reviewer, editor, administrator):"
+
+# Read the password without displaying it (silent mode: -s)
+read -r -s USERS_PASSWORD
+
+echo
+
+# Check if the user entered anything
+if [ -z "$USERS_PASSWORD" ]; then
+    echo -e "${RED}ERROR: Password cannot be empty. Exiting.${NC}" >&2
+    exit 1
+fi
+
+export USERS_PASSWORD
+echo -e "${CYAN}USERS_PASSWORD has been set for this session.${NC}"
+
+echo -e "${CYAN}--- Creating system roles ---${NC}"
 ROLES=(reviewer editor administrator)
 
 for role in "${ROLES[@]}"; do
     if invenio roles create "$role" 2>/dev/null; then
-        echo "Created role '$role'"
+        echo -e "${RED}Created role '$role'${NC}"
     else
-        echo "Role '$role' already exists. Skipping."
+        echo -e "${YELLOW}Role '$role' already exists. Skipping.${NC}"
     fi
 done
 
 # Run stage setup script afterwards
-bash "$(dirname "$0")/../scripts/stage_setup.sh"
+echo -e "${CYAN}--- Running stage setup (user creation) script ---${NC}"
+bash -e "$(dirname "$0")/../scripts/stage_setup.sh"
+
+echo -e "${CYAN}--- Role and User setup complete ---${NC}"

--- a/scripts/stage_setup.sh
+++ b/scripts/stage_setup.sh
@@ -3,19 +3,28 @@
 # Requires the environment variable $USERS_PASSWORD to be set before running.
 
 set -e
-set -x
+
+# --- ANSI Color Codes ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+# ------------------------
 
 if [ -z "$USERS_PASSWORD" ] ; then
-  echo "USERS_PASSWORD is not set"
+  echo -e "${RED}ERROR: USERS_PASSWORD is not set${NC}" >&2
   exit 1
 fi
 
+DOMAIN="mbdb-data.org"
 ROLES=(reviewer editor administrator)
 
 # Create users (skip if they already exist)
+echo -e "${CYAN}--- Creating users and profiles ---${NC}"
 for role in "${ROLES[@]}"; do
 
-    EMAIL="${role}@mbdb.org"
+    EMAIL="${role}@${DOMAIN}"
 
     if [[ "$role" == "administrator" ]]; then
         FULL_NAME="Administrátor"
@@ -25,24 +34,30 @@ for role in "${ROLES[@]}"; do
 
     PROFILE_JSON="{\"full_name\": \"$FULL_NAME\"}"
 
-    if ! invenio users create -a -c "$EMAIL" --password "$USERS_PASSWORD" --profile "$PROFILE_JSON" 2>err.out; then
-        if grep -q "already associated with an account" err.out; then
-            echo "User '$EMAIL' already exists. Skipping."
+    if ! ERROR_OUTPUT=$(invenio users create -a -c "$EMAIL" --password "$USERS_PASSWORD" --profile "$PROFILE_JSON" 2>&1 >/dev/null); then
+        if echo "$ERROR_OUTPUT" | grep -q "already associated with an account"; then
+            echo -e "${YELLOW}User '$EMAIL' already exists. Skipping.${NC}"
         else
-            echo "Error creating user '$EMAIL':"
-            cat err.out
+            echo -e "${RED}FATAL ERROR creating user '$EMAIL':${NC}" >&2
+            echo -e "${RED}$ERROR_OUTPUT${NC}" >&2
             exit 1
         fi
+    else
+        echo -e "${GREEN}User '$EMAIL' created successfully.${NC}"
     fi
 
 done
 
 # Assign each user their role
+echo -e "${CYAN}--- Assigning roles ---${NC}"
 for role in "${ROLES[@]}"; do
-    EMAIL="${role}@mbdb.org"
-    invenio roles add "$EMAIL" "$role" || echo "Role '$role' already assigned to '$EMAIL'. Skipping."
+    EMAIL="${role}@${DOMAIN}"
+    invenio roles add "$EMAIL" "$role" 2>/dev/null || echo -e "${YELLOW}Role '$role' already assigned to '$EMAIL'. Skipping.${NC}"
 done
 
 # Allow administration access to the admin role
-invenio access allow administration-access role administrator || \
-    echo "administrator already has administration-access assigned."
+echo -e "${CYAN}--- Granting administration access ---${NC}"
+invenio access allow administration-access role administrator 2>/dev/null || \
+    echo -e "${YELLOW}Administrator already has administration-access assigned. Skipping.${NC}"
+
+echo -e "${CYAN}--- Script finished successfully ---${NC}"


### PR DESCRIPTION
In `common/bootstrap_localdev.sh`, the script now:

- Prompts once for a password that will be used for all feature-role accounts.
- Ensures the three roles reviewer, administrator, and editor exist.
- Automatically creates three corresponding users (if missing) and assigns the roles.
- All users use the @mbdb-data.org domain.

For `stage_setup.sh`:

- The same three users are created in the same way.
- The stage setup logic is appended to the bootstrap script so the same code can be reused both locally and on stage.