### PR TITLE
Modify notification texts - add record ids and links

### DIFF
--- a/common/templates/mbdb/invenio_notifications/email/comment-request-event.create.jinja
+++ b/common/templates/mbdb/invenio_notifications/email/comment-request-event.create.jinja
@@ -14,6 +14,7 @@
     or (created_by if created_by is string else _("Someone"))
 %}
 {% set request_id = invenio_request.id %}
+{% set record_id = notification.context.request.topic.parent.id %}
 {% set request_event_content = invenio_request_event.payload.content | safe %}
 {% set request_title = invenio_request.title | safe %}
 
@@ -28,13 +29,15 @@
 {%- block html_body -%}
   {% set body %}
     <p>
-      {{ _("'@{user_name}' commented on your request '{request_title}' for record id: '{record_id}':").format(
+      {{ _("'@{user_name}' commented on your request '{request_title}' for record id: '{record_id}'").format(
           user_name=event_creator_name,
-          request_title=request_title, record_id=notification.context.request.topic.parent.id
+          request_title=request_title, record_id=record_id
       ) }}
     </p>
 
     <p><em>{{ request_event_content }}</em></p>
+
+    <p>{{ _("You can leave answer to the comment on the request page.") }}</p>
 
     {{ m.button(request_link, _("Check out the request"), bg="#007bff") }}
 
@@ -49,12 +52,15 @@
 
 {%- block plain_body -%}
   {% set body %}
-{{ _("@{user_name} commented on '{request_title}'").format(
+{{ _("@{user_name} commented on your request '{request_title}' for record id: '{record_id}'").format(
     user_name=event_creator_name,
-    request_title=request_title
+    request_title=request_title,
+    record_id=record_id
 ) }}.
 
 {{ request_event_content }}
+
+{{ _("You can leave answer to the comment on the request page.") }}
 
 {{ _("Check out the request: {request_link}").format(request_link=request_link) }}
   {% endset %}
@@ -64,9 +70,11 @@
 
 {# Markdown for Slack/Mattermost/chat #}
 {%- block md_body -%}
-{{ _("*@{user_name}* commented on *{request_title}*").format(user_name=event_creator_name, request_title=request_title) }}.
+{{ _("*@{user_name}* commented on your request *{request_title}* for record id: *{record_id}*").format(user_name=event_creator_name, request_title=request_title, record_id=record_id) }}.
 
 {{ request_event_content }}
+
+{{ _("You can leave answer to the comment on the request page.") }}
 
 [{{ _("Check out the request") }}]({{ request_link }})
 {%- endblock md_body -%}

--- a/common/templates/mbdb/invenio_notifications/email/draft-request-accept-creator.submit.jinja
+++ b/common/templates/mbdb/invenio_notifications/email/draft-request-accept-creator.submit.jinja
@@ -15,12 +15,19 @@
 
 {%- block html_body -%}
   {% set body %}
-    {% trans topic_title=topic_title %}
-      <p>🎉 <b>Great News!</b> Your record <b>"{{ topic_title }}"</b> has successfully passed review and has been <b>ACCEPTED</b> for publication.</p>
+    {% trans topic_id=topic_id, topic_title=topic_title %}
+      <p>🎉 <b>Great News!</b> Your record [{{ topic_id }}] <b>"{{ topic_title }}"</b> has successfully passed review and has been <b>ACCEPTED</b> for publication.</p>
       <p>The record is now in the <i>Accepted</i> state. Once you are ready to publish your record, please click the <b>"Publish draft"</b> button on the record preview page.</p>
     {% endtrans %}
 
     {{ m.button(record_html_page, _("View Record &amp; Publish"), bg="#28a745") }}
+
+    <p>
+      {% trans record_html_page=record_html_page %}
+        If the button does not work, copy and paste this link into your browser:<br>
+        <a href="{{ record_html_page }}">{{ record_html_page }}</a>
+      {% endtrans %}
+    </p>
   {% endset %}
 
   {{ layout.render_html(body, text_align="center") }}
@@ -28,8 +35,8 @@
 
 {%- block plain_body -%}
     {% set body %}
-        {% trans topic_title=topic_title, record_html_page=record_html_page %}
-        Great News! Your record "{{ topic_title }}" has successfully passed review and has been ACCEPTED for publication.
+        {% trans topic_id=topic_id, topic_title=topic_title, record_html_page=record_html_page %}
+        Great News! Your record [{{ topic_id }}] "{{ topic_title }}" has successfully passed review and has been ACCEPTED for publication.
 
         The record is now in the 'Accepted' state. Once you are ready to publish your record,
         please click the "Publish draft" button on the record preview page:

--- a/common/templates/mbdb/invenio_notifications/email/draft-request-creator.submit.jinja
+++ b/common/templates/mbdb/invenio_notifications/email/draft-request-creator.submit.jinja
@@ -15,8 +15,8 @@
 
 {%- block html_body -%}
     {% set body %}
-        {% trans topic_title=topic_title %}
-          <p>Thank you for submitting your record <b>"{{ topic_title }}"</b> to MBDB.</p>
+        {% trans topic_id=topic_id, topic_title=topic_title %}
+          <p>Thank you for submitting your record [{{ topic_id }}] <b>"{{ topic_title }}"</b> to MBDB.</p>
           <p>Your record is now under review. We will notify you if revisions to your record are needed or once the record has been accepted.</p>
         {% endtrans %}
 
@@ -33,8 +33,8 @@
 
 {%- block plain_body -%}
       {% set body %}
-        {% trans topic_title=topic_title, request_html_page=request_html_page %}
-        Thank you for submitting your record "{{ topic_title }}" to MBDB.
+        {% trans topic_id=topic_id, topic_title=topic_title, request_html_page=request_html_page %}
+        Thank you for submitting your record [{{ topic_id }}] "{{ topic_title }}" to MBDB.
 
         Your record is now under review. We will notify you if revisions to your record are needed
         or once the record has been accepted.

--- a/common/templates/mbdb/invenio_notifications/email/draft-request-decline-creator.submit.jinja
+++ b/common/templates/mbdb/invenio_notifications/email/draft-request-decline-creator.submit.jinja
@@ -15,15 +15,22 @@
 
 {%- block html_body -%}
     {% set body %}
-        {% trans topic_title=topic_title %}
-          <p><b>Important Update:</b> Your record <b>"{{ topic_title }}"</b> has been <b>declined</b> to allow further editing.</p>
+        {% trans topic_id=topic_id, topic_title=topic_title %}
+          <p><b>Important Update:</b> Your record [{{topic_id}}] <b>"{{ topic_title }}"</b> has been <b>declined</b> to allow further editing.</p>
           <p>
             Some revisions are needed before the record can be accepted for publication.
-            <b>Please refer to the reviewer's feedback sent in a separate email. The feedback is also available on the request page.</b>
+            <b>Please refer to the reviewer's feedback sent in a separate email. The feedback is also available on the request page. You can leave answers to the feedback and other comments on the request page.</b>
           </p>
         {% endtrans %}
 
         {{ m.button(request_html_page, _("View detailed feedback &amp; status"), bg="#007bff") }}
+
+        <p>
+          {% trans request_html_page=request_html_page %}
+            If the button does not work, copy and paste this link into your browser:<br>
+            <a href="{{ request_html_page }}">{{ request_html_page }}</a>
+          {% endtrans %}
+        </p>
     {% endset %}
 
     {{ layout.render_html(body, text_align="center") }}
@@ -31,12 +38,13 @@
 
 {%- block plain_body -%}
     {% set body %}
-        {% trans topic_title=topic_title, request_html_page=request_html_page %}
-        Your record "{{ topic_title }}" has been declined to allow further editing.
+        {% trans topic_id=topic_id, topic_title=topic_title, request_html_page=request_html_page %}
+        Your record [{{ topic_id }}] "{{ topic_title }}" has been declined to allow further editing.
 
         Some revisions are needed before the record can be accepted for publication.
         Please refer to the reviewer's feedback that has been sent in a separate e-mail.
-        The feedback is also available on the request page:
+        The feedback is also available on the request page.
+        You can leave answers to the feedback and other comments on the request page:
 
         {{ request_html_page }}
         {% endtrans %}

--- a/common/templates/mbdb/invenio_notifications/email/draft-request-receiver.submit.jinja
+++ b/common/templates/mbdb/invenio_notifications/email/draft-request-receiver.submit.jinja
@@ -17,7 +17,7 @@
 {%- block html_body -%}
     {% set body %}
         {% trans topic_id=topic_id, topic_title=topic_title %}
-          <p>A new record, <b> [{{ topic_id}}] "{{ topic_title }}"</b>, has been submitted and is awaiting your review.</p>
+          <p>A new record, [{{ topic_id}}] <b>"{{ topic_title }}"</b>, has been submitted and is awaiting your review.</p>
 
           <p>
             Please check the request page to make sure that the record is not being reviewed by someone else.

--- a/common/templates/mbdb/invenio_notifications/email/draft-request-receiver.submit.jinja
+++ b/common/templates/mbdb/invenio_notifications/email/draft-request-receiver.submit.jinja
@@ -5,18 +5,19 @@
 {% set topic = request.topic %}
 {% set rec_info = topic.metadata.general_parameters.record_information %}
 
+{% set topic_id = topic.id %}
 {% set topic_title = rec_info.title %}
 {% set method = rec_info.resource_type %}
 {% set request_html_page = request.links.self_html %}
 
 {%- block subject -%}
-{{ _("[{method}]: A new MBDB record submitted - '{topic_title}'").format(topic_title=topic_title, method=method) }}
+{{ _("[{method}]: A new MBDB record submitted - '{topic_id}'").format(topic_id=topic_id, method=method) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}
     {% set body %}
-        {% trans topic_title=topic_title %}
-          <p>A new record, <b>"{{ topic_title }}"</b>, has been submitted and is awaiting your review.</p>
+        {% trans topic_id=topic_id, topic_title=topic_title %}
+          <p>A new record, <b> [{{ topic_id}}] "{{ topic_title }}"</b>, has been submitted and is awaiting your review.</p>
 
           <p>
             Please check the request page to make sure that the record is not being reviewed by someone else.
@@ -45,8 +46,8 @@
 
 {%- block plain_body -%}
     {% set body %}
-        {% trans topic_title=topic_title, request_html_page=request_html_page %}
-        A new record "{{ topic_title }}" has been submitted and is awaiting your review.
+        {% trans topic_id=topic_id, topic_title=topic_title, request_html_page=request_html_page %}
+        A new record [{{ topic_id }}] "{{ topic_title }}" has been submitted and is awaiting your review.
 
         Please check the request page (link below) to make sure that the record is not being
         reviewed by someone else. If you decide to review this record, leave a comment

--- a/common/templates/mbdb/invenio_notifications/email/publish-draft-request-event.accept.jinja
+++ b/common/templates/mbdb/invenio_notifications/email/publish-draft-request-event.accept.jinja
@@ -15,8 +15,8 @@
 
 {%- block html_body -%}
     {% set body %}
-        {% trans topic_title=topic_title, record_html_page=record_html_page %}
-          <p><b>Congratulations!</b> Your record <b>"{{ topic_title }}"</b> has been successfully <b>PUBLISHED</b>.</p>
+        {% trans topic_id=topic_id, topic_title=topic_title, record_html_page=record_html_page %}
+          <p><b>Congratulations!</b> Your record [{{ topic_id }}] <b>"{{ topic_title }}"</b> has been successfully <b>PUBLISHED</b>.</p>
           <p>The record is now available here: <a href="{{ record_html_page }}">{{ record_html_page }}</a></p>
         {% endtrans %}
 
@@ -29,8 +29,8 @@
 
 {%- block plain_body -%}
     {% set body %}
-        {% trans topic_title=topic_title, record_html_page=record_html_page %}
-        Congratulations! Your record "{{ topic_title }}" has been successfully PUBLISHED.
+        {% trans topic_id=topic_id, topic_title=topic_title, record_html_page=record_html_page %}
+        Congratulations! Your record [{{ topic_id }}] "{{ topic_title }}" has been successfully PUBLISHED.
 
         The record is now available here:
         {{ record_html_page }}


### PR DESCRIPTION
Modify notifications so that subject contains record id instead of title, record ids added to e-mail body, for "decline" and "accepted" add link if button non-functional.