### PR TITLE
Add BLI instrument Octet R8e

### DIFF
--- a/common/fixtures/instruments.yaml
+++ b/common/fixtures/instruments.yaml
@@ -253,6 +253,13 @@ props:
   manufacturer: 'Sartorius'
   technique: "BLI"
 ---
+id: 'ins:60'
+title:
+  en: 'Octet R8e (Eight-Channel System)'
+props:
+  manufacturer: 'Sartorius'
+  technique: "BLI"
+---
 # SPR instruments
 id: 'ins:36'
 title:


### PR DESCRIPTION
'Octet R8e (Eight-Channel System)' which is an enhanced version of 'Octet R8 (Eight-Channel System)' was added to instruments vocabulary under id: 'ins:60'